### PR TITLE
Use ParamSpec for query function

### DIFF
--- a/tadl/query.py
+++ b/tadl/query.py
@@ -43,7 +43,9 @@ class Query(Generic[TParamSpec, TElt]):
     def __set_name__(self, owner: type, name: str) -> None:
         self.__name = name
 
-    def __get__(self, instance: TSelf, owner: type) -> QueryInstance[TSelf, TParamSpec, TElt]:
+    def __get__(
+        self, instance: TSelf, owner: type
+    ) -> QueryInstance[TSelf, TParamSpec, TElt]:
         if instance is None:
             raise ValueError(
                 "QueryLoaderDescriptor must be accessed through an instance."
@@ -130,11 +132,15 @@ class QueryInstance(Generic[TSelf, TParamSpec, TElt]):
         self.__query_fn = query_fn
         self.__interfaces = interfaces
 
-    async def query(self, *args: TParamSpec.args, **kwargs: TParamSpec.kwargs) -> list[TElt]:
+    async def query(
+        self, *args: TParamSpec.args, **kwargs: TParamSpec.kwargs
+    ) -> list[TElt]:
         elts = await self.__query_fn(self.__instance, *args, **kwargs)
         for interface in self.__interfaces:
             interface.prime_many(elts)
         return elts
 
-    async def __call__(self, *args: TParamSpec.args, **kwargs: TParamSpec.kwargs) -> list[TElt]:
+    async def __call__(
+        self, *args: TParamSpec.args, **kwargs: TParamSpec.kwargs
+    ) -> list[TElt]:
         return await self.query(*args, **kwargs)

--- a/tests/test_query_paramspec.py
+++ b/tests/test_query_paramspec.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Callable, reveal_type, Literal
+
+import pytest
+
+import tadl
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_query_paramspec() -> None:
+    """
+    Test that we can use custom arguments for the query function and that the
+    typing with ParamSpec is working correctly.
+    """
+
+    class WordService:
+        @tadl.query
+        async def __query(
+            self,
+            criterion: Callable[[str], bool],
+            *,
+            language: Literal["en", "fr"] = "en",
+        ) -> list[str]:
+            words = (
+                ["hello", "goodbye", "hotel"]
+                if language == "en"
+                else ["bonjour", "au revoir", "hôtel"]
+            )
+            return [word for word in words if criterion(word)]
+
+        @__query.group_interface(
+            key=lambda word: word[0],
+            sort=lambda word: word,
+        )
+        async def for_english_first_letter(self, letters: list[str]) -> list[str]:
+            """
+            Load a list of words that start with the given first letter.
+            """
+            return await self.__query(lambda word: word[0] in letters)
+
+        @__query.group_interface(
+            key=lambda word: word[0],
+            sort=lambda word: word,
+        )
+        async def for_french_first_letter(self, letters: list[str]) -> list[str]:
+            """
+            Load a list of words that start with the given first letter.
+            """
+            return await self.__query(lambda word: word[0] in letters, language="fr")
+
+    w = WordService()
+    assert await w.for_english_first_letter.load("h") == ["hello", "hotel"]
+    assert await w.for_french_first_letter.load("b") == ["bonjour"]
+    assert await w.for_french_first_letter.load("h") == ["hôtel"]


### PR DESCRIPTION
Using `ParamSpec` allows passing arbitrary arguments to the query function, even keyword arguments. It probably makes sense to keep the interface functions (`batch_loader`, `group_loader`) since we need to know that the loaded objects are uniquely identified by their key.